### PR TITLE
Fix:Linux追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.4-x86_64-linux)
+      racc (~> 1.4)
     pg (1.5.4)
     psych (5.1.0)
       stringio
@@ -190,6 +192,8 @@ GEM
     stringio (3.0.8)
     tailwindcss-rails (2.0.30-arm64-darwin)
       railties (>= 6.0.0)
+    tailwindcss-rails (2.0.30-x86_64-linux)
+      railties (>= 6.0.0)
     thor (1.2.2)
     timeout (0.4.0)
     turbo-rails (1.4.0)
@@ -217,6 +221,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
HerokuデプロイについてLinuxのインストールが必要だったため、追加。